### PR TITLE
Add overflow-y to the setting List

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -34,3 +34,7 @@ ul#settings {
 li {
   break-inside: avoid-column;
 }
+#settingList {
+  height: 500px;
+  overflow-y: auto;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,7 +43,7 @@ export default function App() {
             known settings.
           </p>
         </Box>
-        <Box>
+        <Box id="settingList">
           <SettingsList sdk={sdk} />
         </Box>
         <Box>


### PR DESCRIPTION
Hi Chris, I added a really small change to settingList box, this way we can see the changes to the switching without scrolling back up to the model.

App.tsx (line 46)
<Box id="settingList">
<SettingsList sdk={sdk} />
</Box>

App.css (line 37)
#settingList {
height: 500px; /* Define a height */
overflow-y: auto; /* Enable vertical scrollbar */
}

https://mp-showcase-settings-gmv2sx.stackblitz.io
